### PR TITLE
Fix assertion error in lmm_add_free (e.g. when block=0x2345, size=2)

### DIFF
--- a/lmm/lmm_add_free.c
+++ b/lmm/lmm_add_free.c
@@ -32,7 +32,7 @@ void lmm_add_free(lmm_t *lmm, void *block, oskit_size_t size)
 	max &= ~ALIGN_MASK;
 
 	/* If after alignment we have nothing left, we're done.  */
-	if (max >= min)
+	if (max <= min)
 		return;
 
 	/* Add the block to the free list(s) of whatever region(s) it overlaps.

--- a/lmm/lmm_add_free.c
+++ b/lmm/lmm_add_free.c
@@ -30,10 +30,9 @@ void lmm_add_free(lmm_t *lmm, void *block, oskit_size_t size)
 	   Here we can assume no such thing.  */
 	min = (min + ALIGN_MASK) & ~ALIGN_MASK;
 	max &= ~ALIGN_MASK;
-	assert(max >= min);
 
 	/* If after alignment we have nothing left, we're done.  */
-	if (max == min)
+	if (max >= min)
 		return;
 
 	/* Add the block to the free list(s) of whatever region(s) it overlaps.


### PR DESCRIPTION
Fixes https://github.com/OSPreservProject/oskit/issues/1